### PR TITLE
Added support files that allow indexing of a MS NTFS MFT file

### DIFF
--- a/configfiles/010-csv-input.conf
+++ b/configfiles/010-csv-input.conf
@@ -1,0 +1,9 @@
+input {
+
+file
+	{	
+	path => "/usr/local/logstash-mft/*.csv"
+	type => "mft_dump"
+	start_position => "beginning"
+	}
+}

--- a/configfiles/400-mft_dump.conf
+++ b/configfiles/400-mft_dump.conf
@@ -1,0 +1,86 @@
+#Place holder for MFT config file
+filter {
+    csv {
+        columns => [
+        "recno", 
+        "deleted_status", 
+        "directory", 
+        "ads_statu",
+        "filename",
+        "siCreateTime", 
+        "siAccessTime",
+        "siModTime",
+        "siMFTModTime",
+        "ActualSize",
+        "AllocSize",	
+        "Extention",
+        "FullPath",
+        "fnCreateTime",
+        "fnAccessTime",
+        "fnModTime",
+        "fnMFTModTime",
+        "ReadOnly",
+        "Hidden",
+        "System",
+        "Hostname"
+        ]
+        separator => ","
+        }                
+       
+       grok {
+       patterns_dir => "/usr/local/sof-elk/grok-patterns"
+       match => { "path" => "%{ENDPOINT_extract:endpoint}" }
+       }
+
+       
+   
+
+        date { 
+            match => ["siCreateTime", "yyyy-MM-dd HH:mm:ss"]
+            target => "siCreateTime"
+            tag_on_failure => ["_dateparsefailure"]
+       }
+
+        date { 
+            match => ["siAccessTime", "yyyy-MM-dd HH:mm:ss"]
+            target => "siAccessTime"
+            tag_on_failure => ["_dateparsefailure"]
+       }
+
+        date { 
+            match => ["siModTime", "yyyy-MM-dd HH:mm:ss"]
+            target => "siModTime"
+            tag_on_failure => ["_dateparsefailure"]
+       }
+       
+       date { 
+            match => ["siMFTModTime", "yyyy-MM-dd HH:mm:ss"]
+            target => "siMFTModTime"
+            tag_on_failure => ["_dateparsefailure"]
+       }
+
+    date { 
+            match => ["fnCreateTime", "yyyy-MM-dd HH:mm:ss"]
+            target => "fnCreateTime"
+            tag_on_failure => ["_dateparsefailure"]
+       }
+
+date { 
+            match => ["fnAccessTime", "yyyy-MM-dd HH:mm:ss"]
+            target => "fnAccessTime"
+            tag_on_failure => ["_dateparsefailure"]
+       }
+       
+date { 
+            match => ["fnModTime", "yyyy-MM-dd HH:mm:ss"]
+            target => "fnModTime"
+            tag_on_failure => ["_dateparsefailure"]
+       }
+
+date { 
+            match => ["fnMFTModTime", "yyyy-MM-dd HH:mm:ss"]
+            target => "fnMFTModTime"
+            tag_on_failure => ["_dateparsefailure"]
+       }
+
+}

--- a/configfiles/900-elasticsearch-output.conf
+++ b/configfiles/900-elasticsearch-output.conf
@@ -23,6 +23,14 @@ output {
             template_overwrite => true
         }
 
+
+# MFT file data
+    } if [type] == "mft_dump" {
+        elasticsearch {
+           index => "mftdump-%{+YYYY.MM.dd}"
+           #hosts => "http://192.168.248.128:9200"
+        }
+        
     # syslog messages
     } else if "process_syslog" in [tags] or [type] == "passivedns" or [type] == "archive-passivedns" {
         elasticsearch {

--- a/grok-patterns/mft_patterns
+++ b/grok-patterns/mft_patterns
@@ -1,0 +1,2 @@
+#MFT Patterns
+ENDPOINT_extract ([^\/]+$)


### PR DESCRIPTION
The following is a start that allows sof-elk to take in a MFT CSV created by the tool found here 
http://malware-hunters.net/2011/03/30/introducing-mftdump-forensic-tool/

Creating the CSV file one will need to cat the file contents to awk statement, see below.

`cat MFT_DUMP_FILE_NAME | awk -F "\t" '{print $1 "," $2 "," $3 "," $4 "," $5 "," $6 "," $7 ","$8 ","$9 ","$10 ","$11 ","$12 ","$13 "," $14"," $15 "," $16 "," $17 "," $18 "," $19 "," $20"," $21}' >  ENDPOINTNAME.CSV`

Following sof-elk conventions place the CSV file into /user/local/logstash-mft
-- The name of the CSV, ie (ENDPOINTNAME.CSV) will be parsed out by logstash and mapped to the field "endpoint" in elasticsearch.

Logstash should parse the csv file and send the values to an elastic index, mftdump.

