### PR TITLE
Do not parse CNAME as IP

### DIFF
--- a/configfiles/6014-passivedns.conf
+++ b/configfiles/6014-passivedns.conf
@@ -46,7 +46,7 @@ filter {
       }
     }
 
-    if [answer] {
+    if [answer] and [querytype] != "CNAME" {
       grok {
         match => [ "answer", "^%{IPV4:answer_ip}$" ]
         match => [ "answer", "^%{IPV6:answer_ip}$" ]


### PR DESCRIPTION
If the querytype is CNAME we cant parse the answer as a IP