### PR TITLE
optimize number of shards and replica for single-node cluster

### DIFF
--- a/lib/elasticsearch-.kibana-template.json
+++ b/lib/elasticsearch-.kibana-template.json
@@ -3,7 +3,8 @@
     ".kibana"
   ],
   "settings" : {
-    "number_of_shards" : 1,
+    "number_of_shards" : "1",
+    "number_of_replicas" : "0",
     "index.mapper.dynamic": false
   },
   "mappings" : {

--- a/lib/elasticsearch-httpdlog-template.json
+++ b/lib/elasticsearch-httpdlog-template.json
@@ -4,6 +4,8 @@
   ],
   "settings": {
     "index": {
+      "number_of_shards" : "1",
+      "number_of_replicas" : "0",
       "refresh_interval": "5s"
     }
   },

--- a/lib/elasticsearch-logstash-template.json
+++ b/lib/elasticsearch-logstash-template.json
@@ -4,6 +4,8 @@
   ],
   "settings": {
     "index": {
+      "number_of_shards" : "1",
+      "number_of_replicas" : "0",
       "refresh_interval": "5s"
     }
   },

--- a/lib/elasticsearch-netflow-template.json
+++ b/lib/elasticsearch-netflow-template.json
@@ -4,6 +4,8 @@
   ],
   "settings": {
     "index": {
+      "number_of_shards" : "1",
+      "number_of_replicas" : "0",
       "refresh_interval": "5s"
     }
   },


### PR DESCRIPTION
Sets the number of shards to 1.
As we only have 1 node in the elasticsearch cluster this will reduce disk and memory usage.

Also if we only have 1 node the replicas will never be assigned and only use disk space.
Removing replicas will reduce disk space and improve indexing speed.