### PR TITLE
Update 6100-httpd.conf

### DIFF
--- a/configfiles/6100-httpd.conf
+++ b/configfiles/6100-httpd.conf
@@ -58,7 +58,11 @@ filter {
           "%{TIMESTAMP_ISO8601:timestamp} %{NOTSPACE:hostname} %{WORD:request_method} %{URIPATH:request} %{NOTSPACE:query_string} %{NUMBER:destination_port} %{USER:ident} %{IPORHOST:source_ip} %{NOTSPACE:useragent} %{NOTSPACE:cookie} %{NOTSPACE:referrer} %{NOTSPACE:hostname} %{NUMBER:response_code} %{NUMBER:response_sub} %{NUMBER:win_status} %{NUMBER:destination_bytes} %{NUMBER:source_bytes} %{NUMBER:response_time}",
 
           # 2020-07-01 00:00:00 10.129.19.12 GET /en/whatever - 443 - 10.129.19.5 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/81.0.4044.113+Safari/537.36 200 0 0 26863
-          "%{TIMESTAMP_ISO8601:timestamp} %{IPORHOST:destination_ip} %{WORD:request_method} %{URIPATH:request} %{NOTSPACE:query_string} %{NUMBER:destination_port} %{USER:ident} %{IPORHOST:source_ip} %{NOTSPACE:useragent} %{NUMBER:response_code} %{NUMBER:response_sub} %{NUMBER:win_status} %{NUMBER:response_time}"
+          "%{TIMESTAMP_ISO8601:timestamp} %{IPORHOST:destination_ip} %{WORD:request_method} %{URIPATH:request} %{NOTSPACE:query_string} %{NUMBER:destination_port} %{USER:ident} %{IPORHOST:source_ip} %{NOTSPACE:useragent} %{NUMBER:response_code} %{NUMBER:response_sub} %{NUMBER:win_status} %{NUMBER:response_time}",
+          
+          # IIS logs from an Exchange Server
+          # 2020-07-01 00:00:00 10.129.19.12 GET /en/whatever - 443 DOMAIN/user.name 10.129.19.5 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/81.0.4044.113+Safari/537.36 /path/folder 200 0 0 26863
+          "%{TIMESTAMP_ISO8601:timestamp} %{IPORHOST:destination_ip} %{WORD:request_method} %{URIPATH:request} %{NOTSPACE:query_string} %{NUMBER:destination_port} %{NOTSPACE:ident} %{IPORHOST:source_ip} %{NOTSPACE:useragent} %{NOTSPACE:referrer} %{NUMBER:response_code} %{NUMBER:response_sub} %{NUMBER:win_status} %{NUMBER:response_time}"
         ]
       }
 


### PR DESCRIPTION
Updated IIS parser to cover logs produced by an Exchange Server. Also includes an update to the 'ident' parameter to account for a Windows-based user account that occurs in IIS logs on an Exchange Server.