### PR TITLE
Fix TASK [cerebro : Open firewall ports] when firewalld and it's Pyth…

### DIFF
--- a/ansible/roles/sof-elk_base/defaults/main.yml
+++ b/ansible/roles/sof-elk_base/defaults/main.yml
@@ -28,6 +28,7 @@ base_yum_packages:
   - python2-pip
   - python-requests
   - python-six
+  - python-firewall
   - python3
   - python3-devel
   - python3-pip
@@ -40,6 +41,7 @@ base_yum_packages:
   - whois
   - yum-plugin-post-transaction-actions
   - yum-utils
+  - firewalld
 
 vmware_yum_packages:
   - open-vm-tools


### PR DESCRIPTION
…on module are not installed

TASK [cerebro : Open firewall ports] ********************************************************************************************************************************************************
fatal: [sof-elk]: FAILED! => {"changed": false, "msg": "Python Module not found: firewalld and its python module are required for this module,                         version 0.2.11 or newer required (0.3.9 or newer for offline operations)"}

fatal: [sof-elk]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 54.169.234.130 closed.\r\n", "module_stdout": "ERROR: Failed to load '/etc/firewalld/firewalld.conf': [Errno 2] No such file or directory: '/etc/firewalld/firewalld.conf'\r\nWARNING: Using fallback firewalld configuration settings.\r\nERROR: No icmptypes found.\r\nERROR: No services found.\r\nFATAL ERROR: Zone 'block' is not available.\r\nFATAL ERROR: Zone 'drop' is not available.\r\nFATAL ERROR: Zone 'trusted' is not available.\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}