### PR TITLE
Force symlink creation in TASK [filebeat : Configure filebeat] when f…

### DIFF
--- a/ansible/roles/filebeat/tasks/main.yml
+++ b/ansible/roles/filebeat/tasks/main.yml
@@ -10,6 +10,7 @@
     src: '/usr/local/sof-elk/lib/configfiles/filebeat.yml'
     dest: '/etc/filebeat/filebeat.yml'
     state: link
+    force: yes
   notify: restart filebeat
   tags: sof-elk_filebeat
 


### PR DESCRIPTION
…ile already exists after the installation

TASK [filebeat : Configure filebeat] ********************************************************************************************************************************************************
fatal: [sof-elk]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0600", "msg": "refusing to convert from file to symlink for /etc/filebeat/filebeat.yml", "owner": "root", "path": "/etc/filebeat/filebeat.yml", "secontext": "system_u:object_r:etc_t:s0", "size": 9984, "state": "file", "uid": 0}