### PR TITLE
Fix in the installation of logstash plugins

### DIFF
--- a/ansible/roles/logstash/tasks/main.yml
+++ b/ansible/roles/logstash/tasks/main.yml
@@ -11,7 +11,7 @@
     state: present
   with_items:
     - logstash-input-relp
-    - logstash-input-input-google_pubsub
+    - logstash-input-google_pubsub
     - logstash-filter-tld
     - logstash-filter-rest
     - logstash-filter-json_encode


### PR DESCRIPTION
fix a typo preventing the correct installation of the `logstash-input-google_pubsub` plugin