### PR TITLE
Fixing Microsoft 365 multiline JSON logs parsing

### DIFF
--- a/configfiles/1001-preprocess-json.conf
+++ b/configfiles/1001-preprocess-json.conf
@@ -20,7 +20,7 @@ filter {
     # this is a mess..  super annoying and prone to collateral damage
     # therefore, only apply this to types where the special attention is known to be required
     # maybe this is better suited to a separate pre-pre-processor? ugh...
-    if [type] == "gcp" or [type] == "archive-netflow" {
+    if [type] == "gcp" or [type] == "archive-netflow" or [type] == "microsoft365" {
       if [message] =~ "},$" {
         mutate {
             gsub => [ "message", "},\z", "}" ]

--- a/lib/filebeat_inputs/microsoft365.yml
+++ b/lib/filebeat_inputs/microsoft365.yml
@@ -8,6 +8,14 @@
   paths:
     - /logstash/microsoft365/**/*.json
   close.on_state_change.inactive: 5m
+  exclude_lines: ['^\[$']
+  parsers:
+  - multiline:
+      pattern: '^{'
+      negate: true
+      match: after
+      max_lines: 10000000
+      flush_pattern: '^}'
   clean_removed: true
   fields_under_root: true
   fields:


### PR DESCRIPTION
Hi,

Idk if this pull request can be related to issue #285, but I think I fixed multiline JSON array logs for M365 UAL parsing problem.

Here is a sample (anonymised), if you want to test it by yourself:

```
[
{
"CreationTime": "2023-05-31T22:52:10",
"Operation": "FileAccessed",
"UserId": "app@sharepoint",
"ClientIP": "1.2.3.4",
"ObjectId": "https://anon.sharepoint.com/sites/folder/anon.aspx",
"EventSource": "SharePoint",
"UserAgent": "ISV|Veeam Software|Veeam Backup for Office 365/5.0",
"SourceFileExtension": "aspx"
},
{
"CreationTime": "2023-05-31T22:52:10",
"Operation": "FileAccessed",
"UserId": "app@sharepoint",
"ClientIP": "1.2.3.4",
"ObjectId": "https://anon.sharepoint.com/sites/folder/anonymous.aspx",
"EventSource": "SharePoint",
"UserAgent": "ISV|Veeam Software|Veeam Backup for Office 365/5.0",
"SourceFileExtension": "aspx"
},
{
"CreationTime": "2023-05-31T21:52:09",
"Operation": "FileAccessed",
"UserId": "app@sharepoint",
"ClientIP": "1.2.3.4",
"ObjectId": "https://anon.sharepoint.com/sites/folder/anony.aspx",
"EventSource": "SharePoint",
"UserAgent": "ISV|Veeam Software|Veeam Backup for Office 365/5.0",
"SourceFileExtension": "aspx"
}
]
```
Thanks!