### PR TITLE
Sort using isort on aws-cloudtrail2sof-elk.py file

### DIFF
--- a/supporting-scripts/aws-cloudtrail2sof-elk.py
+++ b/supporting-scripts/aws-cloudtrail2sof-elk.py
@@ -5,10 +5,10 @@
 # This script will recursively read a file or directory tree of JSON AWS Cloudtrail logs and output in a format that SOF-ELK® can read.  Both gzipped and native JSON is supported.
 
 import argparse
-import sys
-import os
-import json
 import gzip
+import json
+import os
+import sys
 
 default_destdir = '/logstash/aws/'
 


### PR DESCRIPTION
This is a minor change: only change the sort while importing Python modules. The objective is to make the code more readable and standardized.