### PR TITLE
Fixing AWS CloudTrail username parsing

### DIFF
--- a/configfiles/6901-aws.conf
+++ b/configfiles/6901-aws.conf
@@ -25,7 +25,7 @@ filter {
         "[raw][userIdentity][accessKeyId]" => "access_key_id"
         "[raw][userIdentity][type]" => "user_type"
         "[raw][userIdentity][arn]" => "arn"
-        "[raw][userIdentity][username]" => "username"
+        "[raw][userIdentity][userName]" => "username"
         "[raw][userIdentity][sessionContext]" => "raw_session_context"
         "[raw][requestParameters][bucketName]" => "bucket_name"
         "[raw][requestParameters][Host]" => "hostname"


### PR DESCRIPTION
Hey @philhagen ! I was working with CloudTrail log files from the flaws.cloud dataset here: https://summitroute.com/blog/2020/10/09/public_dataset_of_cloudtrail_logs_from_flaws_cloud/

I noticed that the userName field wasn't parsing properly (presumably due to case sensitivity in the mutation configurations), so I fixed that and tested it on my local VM.