### PR TITLE
IIS logs with domain.local not parsed

### DIFF
--- a/grok-patterns/sof-elk_custom
+++ b/grok-patterns/sof-elk_custom
@@ -43,7 +43,8 @@ URIPATH_CUSTOM %{URIPATH}|\*
 FULL_URL (?:%{WORD:[url][scheme]}://)?(?:%{IPORHOST:[url][domain]}(?::%{POSINT:[destination][port]})?)?(?:%{URIPATH_CUSTOM:[url][path]})?(?:\?%{NOTSPACE:[url][query]})?
 
 # custom HTTPD common format (should flow to the combined format) to allow email address as the username, separate out query string from stub request
-HTTPDUSER %{EMAILADDRESS}|%{WORD}[/\\]%{USER}|%{USER}
+# HTTPDUSER updated to also take into account domains with '.' eg. domain.local\username
+HTTPDUSER %{EMAILADDRESS}|%{WORD}(\.%{WORD})?[/\\]%{USER}|%{USER}
 COMMONAPACHELOG_CUSTOM %{IPORHOST:[source][ip]} %{HTTPDUSER:[client][user][name]} %{HTTPDUSER:[server][user][name]} \[%{HTTPDATE:timestamp}\] "(?:%{WORD:[http][request][method]} %{FULL_URL}(?: HTTP/%{NUMBER:[http][version]})?|%{DATA:[sof-elk][rawrequest]})" %{NUMBER:[http][response][status_code]} (?:%{NUMBER:[destination][bytes]}|-)
 COMMONPROXYLOG_CUSTOM %{COMMONAPACHELOG_CUSTOM} %{WORD:[http][proxy][cache_status]}:%{WORD:[http][proxy][cache_hierarchy_status]}
 COMBINEDAPACHELOG_CUSTOM (?:%{COMMONAPACHELOG_CUSTOM}) %{QS:[http][request][referrer]} %{QS:[user_agent][original]}


### PR DESCRIPTION
Hi @philhagen !
Testing some IIS logs with username format domain.local\username and they seemed to fail parsing because of the '.'

Example log

```
2024-05-29 21:10:57 192.168.1.47 POST /FOO/some/path/login.aspx - 443 domain.tld\test 1.1.1.1 Mozilla/5.0+(Windows+NT+10.0;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/129.0.0.0+Safari/537.36 https://2.3.4.5/somepath/login.aspx 302 0 0 162
``` 

Tested a custom version of the sof-elk_custom HTTPUSER pattern from 
https://github.com/philhagen/sof-elk/blob/764bcf9b00a3db52bfdf61f1c16314d62f977ecf/grok-patterns/sof-elk_custom#L46

And changed it to 
```
HTTPDUSER %{EMAILADDRESS}|%{WORD}(\.%{WORD})?[/\\]%{USER}|%{USER}
```

This parses the logs correctly. 
I have done some limited testing with usernames:
```
domain\user
domain.test\user.test
user@domain.com
user
```
There might be some cases like domain.test.test\user that breaks it. 

Let me know what you think 😃 

