### PR TITLE
Fixed indentation of "tags" in "Set elk_user to hushed logins"

### DIFF
--- a/ansible/roles/sof-elk_base/tasks/main.yml
+++ b/ansible/roles/sof-elk_base/tasks/main.yml
@@ -182,7 +182,7 @@
     mode: 0640
     owner: elk_user
     group: elk_user
-    tags: sof-elk_base
+  tags: sof-elk_base
 
 - name: Set up pre-login banner template
   ansible.builtin.template:


### PR DESCRIPTION
Fixed indentation of "tags" in "Set elk_user to hushed logins" that prevented proper deployment