### PR TITLE
Added Curl to dependencies

### DIFF
--- a/ansible/roles/sof-elk_base/defaults/main.yml
+++ b/ansible/roles/sof-elk_base/defaults/main.yml
@@ -12,6 +12,7 @@ base_apt_packages:
   - cifs-utils
   - console-data
   - cron
+  - curl
   - eject
   - exfat-fuse
   - file


### PR DESCRIPTION
Script "/usr/local/sof-elk/supporting-scripts/wait_for_es.sh" uses Curl to check when Elasticsearch is up. If Curl is not installed, the curl command fails on every iteration and the while loop never exits, causing the script to run indefinitely