### PR TITLE
Add Volatility3 memory forensics parsers for SOF-ELK integration

### DIFF
--- a/configfiles-UNSUPPORTED/1500-preprocess-volatility.conf
+++ b/configfiles-UNSUPPORTED/1500-preprocess-volatility.conf
@@ -1,0 +1,46 @@
+# SOF-ELK Configuration File
+# Volatility Memory Forensics - Master Tagger
+#
+# This preprocessing filter automatically detects Volatility data and
+# extracts the module type from the file path, setting appropriate tags
+# and type field for downstream processing.
+#
+# Path pattern: /logstash/volatility/<module>/filename.json
+# Examples:
+#   /logstash/volatility/pslist/case001.json    → type: volatility-pslist
+#   /logstash/volatility/netscan/case001.json   → type: volatility-netscan
+#
+# This runs BEFORE the 6000-series filters to ensure proper routing.
+
+filter {
+  # Only process if this is Volatility data (check file path or existing type label)
+  if [log][file][path] =~ /volatility/ or [type] == "volatility" or "volatility" in [tags] {
+
+    # Extract the module name from the folder path automatically
+    # This looks for the word after /volatility/ and sets it as the type
+    if [log][file][path] {
+      grok {
+        match => { "[log][file][path]" => "/volatility/(?<v_module>[^/]+)/" }
+        tag_on_failure => []
+      }
+    }
+
+    # If we successfully extracted a module name, tag and set type
+    if [v_module] {
+      mutate {
+        add_tag => [ "volatility", "memory_forensics", "volatility-%{v_module}" ]
+        replace => { "type" => "volatility-%{v_module}" }
+      }
+    } else {
+      # Fallback: just mark as generic volatility if we couldn't extract module
+      mutate {
+        add_tag => [ "volatility", "memory_forensics" ]
+      }
+    }
+
+    # Add source identification
+    mutate {
+      add_field => { "[@metadata][data_source]" => "volatility" }
+    }
+  }
+}

--- a/configfiles-UNSUPPORTED/6000-volatility-input.conf
+++ b/configfiles-UNSUPPORTED/6000-volatility-input.conf
@@ -1,0 +1,82 @@
+# Logstash Input Configuration for Volatility Memory Forensics
+# ==============================================================
+#
+# SOF-ELK Architecture Note:
+# --------------------------
+# SOF-ELK uses Filebeat to monitor filesystem directories, NOT Logstash file inputs.
+#
+# Data flow:
+#   1. Files placed in /logstash/volatility/<plugin>/*.json
+#   2. Filebeat watches these directories (configured in filebeat.yml)
+#   3. Filebeat sends to Logstash Beats input (port 5044)
+#   4. Logstash filters process the events (configs 6001-6012)
+#   5. Data indexed to Elasticsearch
+#
+# Required Directory Structure on SOF-ELK:
+# -----------------------------------------
+#   /logstash/volatility/pslist/   - Process list (windows.pslist)
+#   /logstash/volatility/pstree/   - Process tree (windows.pstree)
+#   /logstash/volatility/psscan/   - Process scan (windows.psscan)
+#   /logstash/volatility/netscan/  - Network connections (windows.netscan)
+#   /logstash/volatility/cmdline/  - Command lines (windows.cmdline)
+#   /logstash/volatility/netstat/  - Network stats (windows.netstat)
+#
+# Setup Commands (on SOF-ELK VM):
+# --------------------------------
+#   sudo mkdir -p /logstash/volatility/{pslist,pstree,psscan,netscan,cmdline,netstat}
+#   sudo chown -R filebeat:filebeat /logstash/volatility/
+#   sudo chmod 755 /logstash/volatility/
+#
+# Filebeat Configuration:
+# -----------------------
+# Add the filebeat-volatility.yml configuration to SOF-ELK's filebeat.yml
+# See: ../filebeat/filebeat-volatility.yml
+#
+# The Beats input is already configured in SOF-ELK (typically in a file like
+# /etc/logstash/conf.d/0001-input-beats.conf or similar) and listens on port 5044.
+#
+# NO ADDITIONAL INPUT CONFIGURATION IS NEEDED HERE.
+#
+# Filebeat will automatically tag events with:
+#   - type: "volatility-<plugin>"  (e.g., "volatility-netscan")
+#   - tags: ["volatility", "<plugin>", "memory_forensics"]
+#
+# These fields are used by our filter configurations (6001-6012) to route
+# events to the correct processing pipeline.
+#
+# ==============================================================
+# IMPORTANT: File Size Requirement
+# ==============================================================
+# Filebeat 9+ uses fingerprinting and requires files to be at least 1,024 bytes.
+# Smaller files will be ignored. Our NDJSON files from batch_process.py typically
+# exceed this size, but be aware if creating custom inputs.
+#
+# ==============================================================
+# Verification Steps:
+# ==============================================================
+# 1. Check Filebeat is running:
+#      sudo systemctl status filebeat
+#
+# 2. Test Filebeat configuration:
+#      sudo filebeat test config
+#
+# 3. Check Filebeat is harvesting files:
+#      sudo tail -f /var/log/filebeat/filebeat.log
+#
+# 4. Verify Logstash is receiving events:
+#      sudo tail -f /var/log/logstash/logstash-plain.log
+#
+# 5. Check Elasticsearch indices:
+#      curl -s localhost:9200/_cat/indices/volatility-* | sort
+#
+# ==============================================================
+# Data Ingestion Workflow:
+# ==============================================================
+# 1. Run batch_process.py with --output-dir /logstash/volatility
+# 2. NDJSON files are created in /logstash/volatility/<plugin>/
+# 3. Filebeat detects new files and parses NDJSON
+# 4. Filebeat sends to Logstash on localhost:5044
+# 5. Logstash applies filters based on event 'type' field
+# 6. Enriched data sent to Elasticsearch
+# 7. Query in Kibana using index pattern: volatility-*
+#

--- a/configfiles-UNSUPPORTED/6001-volatility-pslist.conf
+++ b/configfiles-UNSUPPORTED/6001-volatility-pslist.conf
@@ -1,0 +1,101 @@
+# Logstash configuration for Volatility windows.pslist output
+# This parser handles JSON format from Volatility3 windows.pslist plugin
+#
+# Usage: Place JSON files in the input directory configured below
+# Index Pattern: volatility-pslist-*
+
+filter {
+  # Only process if this is a pslist document
+  if [type] == "volatility-pslist" or "volatility-pslist" in [tags] {
+
+    # Parse JSON if it's a string
+    if [message] {
+      json {
+        source => "message"
+        target => "process"
+      }
+    }
+
+    # Extract process information
+    mutate {
+      add_field => {
+        "process_id" => "%{[process][PID]}"
+        "parent_process_id" => "%{[process][PPID]}"
+        "process_name" => "%{[process][ImageFileName]}"
+        "process_offset" => "%{[process][Offset(V)]}"
+        "thread_count" => "%{[process][Threads]}"
+        "handle_count" => "%{[process][Handles]}"
+        "session_id" => "%{[process][SessionId]}"
+        "is_wow64" => "%{[process][Wow64]}"
+        "file_output" => "%{[process][File output]}"
+      }
+      add_tag => [ "volatility", "memory_forensics", "process_list" ]
+    }
+
+    # Parse timestamps
+    if [process][CreateTime] {
+      date {
+        match => [ "[process][CreateTime]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ]
+        target => "process_create_time"
+      }
+    }
+
+    if [process][ExitTime] and [process][ExitTime] != "N/A" {
+      date {
+        match => [ "[process][ExitTime]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ]
+        target => "process_exit_time"
+      }
+      mutate {
+        add_field => { "process_status" => "exited" }
+      }
+    } else {
+      mutate {
+        add_field => { "process_status" => "running" }
+      }
+    }
+
+    # Convert numeric fields
+    mutate {
+      convert => {
+        "process_id" => "integer"
+        "parent_process_id" => "integer"
+        "thread_count" => "integer"
+        "is_wow64" => "boolean"
+      }
+    }
+
+    # Handle null SessionId
+    if [session_id] == "N/A" or [session_id] == "null" {
+      mutate {
+        remove_field => [ "session_id" ]
+      }
+    } else {
+      mutate {
+        convert => { "session_id" => "integer" }
+      }
+    }
+
+    # Add metadata fields for tracking
+    mutate {
+      add_field => {
+        "volatility_plugin" => "windows.pslist"
+        "analysis_type" => "process_enumeration"
+      }
+    }
+
+    # Clean up
+    mutate {
+      remove_field => [ "message" ]
+    }
+  }
+}
+
+output {
+  if [type] == "volatility-pslist" or "volatility-pslist" in [tags] {
+    elasticsearch {
+      hosts => ["localhost:9200"]
+      index => "volatility-pslist-%{+YYYY.MM.dd}"
+      document_type => "_doc"
+    }
+  }
+}

--- a/configfiles-UNSUPPORTED/6002-volatility-pstree.conf
+++ b/configfiles-UNSUPPORTED/6002-volatility-pstree.conf
@@ -1,0 +1,135 @@
+# Logstash configuration for Volatility windows.pstree output
+# This parser handles JSON format from Volatility3 windows.pstree plugin
+# Note: This preserves the hierarchical structure with __children field
+#
+# Usage: Place JSON files in the input directory configured below
+# Index Pattern: volatility-pstree-*
+
+filter {
+  # Only process if this is a pstree document
+  if [type] == "volatility-pstree" or "volatility-pstree" in [tags] {
+
+    # Parse JSON if it's a string
+    if [message] {
+      json {
+        source => "message"
+        target => "process"
+      }
+    }
+
+    # Extract process information
+    mutate {
+      add_field => {
+        "process_id" => "%{[process][PID]}"
+        "parent_process_id" => "%{[process][PPID]}"
+        "process_name" => "%{[process][ImageFileName]}"
+        "process_offset" => "%{[process][Offset(V)]}"
+        "thread_count" => "%{[process][Threads]}"
+        "handle_count" => "%{[process][Handles]}"
+        "session_id" => "%{[process][SessionId]}"
+        "is_wow64" => "%{[process][Wow64]}"
+      }
+      add_tag => [ "volatility", "memory_forensics", "process_tree" ]
+    }
+
+    # Extract pstree-specific fields
+    if [process][Audit] {
+      mutate {
+        add_field => { "process_path_audit" => "%{[process][Audit]}" }
+      }
+    }
+
+    if [process][Cmd] {
+      mutate {
+        add_field => { "process_commandline" => "%{[process][Cmd]}" }
+      }
+    }
+
+    if [process][Path] {
+      mutate {
+        add_field => { "process_path" => "%{[process][Path]}" }
+      }
+    }
+
+    # Calculate process depth in tree (count asterisks in original tree representation)
+    # This would need to be added by preprocessing
+    if [process_depth] {
+      mutate {
+        convert => { "process_depth" => "integer" }
+      }
+    }
+
+    # Parse timestamps
+    if [process][CreateTime] {
+      date {
+        match => [ "[process][CreateTime]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ]
+        target => "process_create_time"
+      }
+    }
+
+    if [process][ExitTime] and [process][ExitTime] != "N/A" {
+      date {
+        match => [ "[process][ExitTime]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ]
+        target => "process_exit_time"
+      }
+      mutate {
+        add_field => { "process_status" => "exited" }
+      }
+    } else {
+      mutate {
+        add_field => { "process_status" => "running" }
+      }
+    }
+
+    # Convert numeric fields
+    mutate {
+      convert => {
+        "process_id" => "integer"
+        "parent_process_id" => "integer"
+        "thread_count" => "integer"
+        "is_wow64" => "boolean"
+      }
+    }
+
+    # Handle null SessionId
+    if [session_id] == "N/A" or [session_id] == "null" {
+      mutate {
+        remove_field => [ "session_id" ]
+      }
+    } else {
+      mutate {
+        convert => { "session_id" => "integer" }
+      }
+    }
+
+    # Store children count
+    if [process][__children] {
+      ruby {
+        code => "event.set('children_count', event.get('[process][__children]').length)"
+      }
+    }
+
+    # Add metadata fields
+    mutate {
+      add_field => {
+        "volatility_plugin" => "windows.pstree"
+        "analysis_type" => "process_tree"
+      }
+    }
+
+    # Clean up
+    mutate {
+      remove_field => [ "message" ]
+    }
+  }
+}
+
+output {
+  if [type] == "volatility-pstree" or "volatility-pstree" in [tags] {
+    elasticsearch {
+      hosts => ["localhost:9200"]
+      index => "volatility-pstree-%{+YYYY.MM.dd}"
+      document_type => "_doc"
+    }
+  }
+}

--- a/configfiles-UNSUPPORTED/6003-volatility-psscan.conf
+++ b/configfiles-UNSUPPORTED/6003-volatility-psscan.conf
@@ -1,0 +1,109 @@
+# Logstash configuration for Volatility windows.psscan output
+# This parser handles JSON format from Volatility3 windows.psscan plugin
+# psscan scans physical memory for EPROCESS structures, finding hidden processes
+#
+# Usage: Place JSON files in the input directory configured below
+# Index Pattern: volatility-psscan-*
+
+filter {
+  # Only process if this is a psscan document
+  if [type] == "volatility-psscan" or "volatility-psscan" in [tags] {
+
+    # Parse JSON if it's a string
+    if [message] {
+      json {
+        source => "message"
+        target => "process"
+      }
+    }
+
+    # Extract process information
+    mutate {
+      add_field => {
+        "process_id" => "%{[process][PID]}"
+        "parent_process_id" => "%{[process][PPID]}"
+        "process_name" => "%{[process][ImageFileName]}"
+        "process_offset" => "%{[process][Offset(V)]}"
+        "thread_count" => "%{[process][Threads]}"
+        "handle_count" => "%{[process][Handles]}"
+        "session_id" => "%{[process][SessionId]}"
+        "is_wow64" => "%{[process][Wow64]}"
+        "file_output" => "%{[process][File output]}"
+      }
+      add_tag => [ "volatility", "memory_forensics", "process_scan", "hidden_process_detection" ]
+    }
+
+    # Parse timestamps
+    if [process][CreateTime] {
+      date {
+        match => [ "[process][CreateTime]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ]
+        target => "process_create_time"
+      }
+    }
+
+    if [process][ExitTime] and [process][ExitTime] != "N/A" {
+      date {
+        match => [ "[process][ExitTime]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ]
+        target => "process_exit_time"
+      }
+      mutate {
+        add_field => { "process_status" => "exited" }
+      }
+    } else {
+      mutate {
+        add_field => { "process_status" => "running" }
+      }
+    }
+
+    # Convert numeric fields
+    mutate {
+      convert => {
+        "process_id" => "integer"
+        "parent_process_id" => "integer"
+        "thread_count" => "integer"
+        "is_wow64" => "boolean"
+      }
+    }
+
+    # Handle null SessionId
+    if [session_id] == "N/A" or [session_id] == "null" {
+      mutate {
+        remove_field => [ "session_id" ]
+      }
+    } else {
+      mutate {
+        convert => { "session_id" => "integer" }
+      }
+    }
+
+    # Add metadata fields for tracking
+    mutate {
+      add_field => {
+        "volatility_plugin" => "windows.psscan"
+        "analysis_type" => "process_scan"
+        "detection_method" => "physical_memory_scan"
+      }
+    }
+
+    # Mark this for potential hidden process analysis
+    # (comparing psscan results with pslist can reveal hidden processes)
+    mutate {
+      add_tag => [ "requires_correlation" ]
+    }
+
+    # Clean up
+    mutate {
+      remove_field => [ "message" ]
+    }
+  }
+}
+
+output {
+  if [type] == "volatility-psscan" or "volatility-psscan" in [tags] {
+    elasticsearch {
+      hosts => ["localhost:9200"]
+      index => "volatility-psscan-%{+YYYY.MM.dd}"
+      document_type => "_doc"
+    }
+  }
+}

--- a/configfiles-UNSUPPORTED/6010-volatility-netscan.conf
+++ b/configfiles-UNSUPPORTED/6010-volatility-netscan.conf
@@ -1,0 +1,156 @@
+# Logstash configuration for Volatility windows.netscan output
+# This parser handles JSON format from Volatility3 windows.netscan plugin
+# Scans for network connections including TCP, UDP, IPv4, and IPv6
+#
+# Usage: Place JSON files in the input directory configured below
+# Index Pattern: volatility-netscan-*
+
+filter {
+  # Only process if this is a netscan document
+  if [type] == "volatility-netscan" or "volatility-netscan" in [tags] {
+
+    # Parse JSON if it's a string
+    if [message] {
+      json {
+        source => "message"
+        target => "network"
+      }
+    }
+
+    # Extract network connection information
+    mutate {
+      add_field => {
+        "process_id" => "%{[network][PID]}"
+        "process_name" => "%{[network][Owner]}"
+        "network_protocol" => "%{[network][Proto]}"
+        "local_address" => "%{[network][LocalAddr]}"
+        "local_port" => "%{[network][LocalPort]}"
+        "foreign_address" => "%{[network][ForeignAddr]}"
+        "foreign_port" => "%{[network][ForeignPort]}"
+        "connection_state" => "%{[network][State]}"
+        "network_offset" => "%{[network][Offset]}"
+      }
+      add_tag => [ "volatility", "memory_forensics", "network_analysis", "netscan" ]
+    }
+
+    # Parse connection creation timestamp
+    if [network][Created] {
+      date {
+        match => [ "[network][Created]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ]
+        target => "connection_created_time"
+      }
+    }
+
+    # Convert numeric fields
+    mutate {
+      convert => {
+        "process_id" => "integer"
+        "local_port" => "integer"
+        "foreign_port" => "integer"
+      }
+    }
+
+    # Determine IP version
+    if [network_protocol] =~ /v6$/ {
+      mutate {
+        add_field => { "ip_version" => "IPv6" }
+      }
+    } else {
+      mutate {
+        add_field => { "ip_version" => "IPv4" }
+      }
+    }
+
+    # Classify connection type
+    if [network_protocol] =~ /^TCP/ {
+      mutate {
+        add_field => { "transport_protocol" => "TCP" }
+      }
+    } else if [network_protocol] =~ /^UDP/ {
+      mutate {
+        add_field => { "transport_protocol" => "UDP" }
+      }
+    }
+
+    # Classify local vs remote connections
+    if [local_address] == "0.0.0.0" or [local_address] == "::" {
+      mutate {
+        add_field => { "connection_type" => "listening" }
+      }
+    } else if [foreign_address] and [foreign_address] != "0.0.0.0" and [foreign_address] != "::" and [foreign_address] != "*" {
+      mutate {
+        add_field => { "connection_type" => "established" }
+      }
+
+      # Check if foreign address is external (not RFC1918/loopback)
+      if [foreign_address] !~ /^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|127\.|::1|fe80:)/ {
+        mutate {
+          add_field => { "connection_scope" => "external" }
+          add_tag => [ "external_connection" ]
+        }
+      } else {
+        mutate {
+          add_field => { "connection_scope" => "internal" }
+        }
+      }
+    }
+
+    # Flag suspicious ports
+    if [local_port] {
+      # Common malware/backdoor ports
+      if [local_port] == 4444 or [local_port] == 31337 or [local_port] == 1337 or [local_port] == 6667 or [local_port] == 6666 {
+        mutate {
+          add_tag => [ "suspicious_port" ]
+        }
+      }
+      # High ports (ephemeral range, but sometimes used for persistence)
+      if [local_port] > 49152 {
+        mutate {
+          add_tag => [ "high_port" ]
+        }
+      }
+    }
+
+    if [foreign_port] {
+      # Outbound to common C2 ports
+      if [foreign_port] == 4444 or [foreign_port] == 8080 or [foreign_port] == 443 or [foreign_port] == 80 {
+        mutate {
+          add_field => { "foreign_port_classification" => "common_c2" }
+        }
+      }
+    }
+
+    # Add metadata fields
+    mutate {
+      add_field => {
+        "volatility_plugin" => "windows.netscan"
+        "analysis_type" => "network_connections"
+      }
+    }
+
+    # GeoIP enrichment for foreign addresses (if GeoIP database available)
+    if [foreign_address] and [connection_scope] == "external" {
+      geoip {
+        source => "foreign_address"
+        target => "foreign_geo"
+        fields => ["city_name", "country_name", "country_code2", "location", "continent_code"]
+        tag_on_failure => ["_geoip_lookup_failure"]
+      }
+    }
+
+    # Clean up
+    mutate {
+      remove_field => [ "message" ]
+    }
+  }
+}
+
+output {
+  if [type] == "volatility-netscan" or "volatility-netscan" in [tags] {
+    elasticsearch {
+      hosts => ["localhost:9200"]
+      index => "volatility-netscan-%{+YYYY.MM.dd}"
+      document_type => "_doc"
+    }
+  }
+}

--- a/configfiles-UNSUPPORTED/6011-volatility-cmdline.conf
+++ b/configfiles-UNSUPPORTED/6011-volatility-cmdline.conf
@@ -1,0 +1,213 @@
+# Logstash configuration for Volatility windows.cmdline output
+# This parser handles JSON format from Volatility3 windows.cmdline plugin
+# Extracts full command line arguments for each process
+#
+# Usage: Place JSON files in the input directory configured below
+# Index Pattern: volatility-cmdline-*
+
+filter {
+  # Only process if this is a cmdline document
+  if [type] == "volatility-cmdline" or "volatility-cmdline" in [tags] {
+
+    # Parse JSON if it's a string
+    if [message] {
+      json {
+        source => "message"
+        target => "cmdline"
+      }
+    }
+
+    # Extract command line information
+    mutate {
+      add_field => {
+        "process_id" => "%{[cmdline][PID]}"
+        "process_name" => "%{[cmdline][Process]}"
+        "command_line" => "%{[cmdline][Args]}"
+      }
+      add_tag => [ "volatility", "memory_forensics", "execution_analysis", "cmdline" ]
+    }
+
+    # Convert numeric fields
+    mutate {
+      convert => {
+        "process_id" => "integer"
+      }
+    }
+
+    # Handle null command lines
+    if [command_line] == "null" or [command_line] == "-" {
+      mutate {
+        remove_field => [ "command_line" ]
+        add_field => { "has_cmdline" => "false" }
+      }
+    } else {
+      mutate {
+        add_field => { "has_cmdline" => "true" }
+      }
+
+      # Analyze command line for suspicious patterns
+      # PowerShell encoded commands
+      if [command_line] =~ /(?i)-enc|-encodedcommand|-e / {
+        mutate {
+          add_tag => [ "powershell_encoded", "suspicious_cmdline" ]
+        }
+      }
+
+      # PowerShell download cradles
+      if [command_line] =~ /(?i)iex|invoke-expression|downloadstring|webclient|downloadfile/ {
+        mutate {
+          add_tag => [ "powershell_download", "suspicious_cmdline" ]
+        }
+      }
+
+      # PowerShell execution policy bypass
+      if [command_line] =~ /(?i)-ep\s+bypass|-executionpolicy\s+bypass/ {
+        mutate {
+          add_tag => [ "powershell_bypass", "suspicious_cmdline" ]
+        }
+      }
+
+      # Hidden/WindowStyle hidden
+      if [command_line] =~ /(?i)-w\s+hidden|-windowstyle\s+hidden|-nop/ {
+        mutate {
+          add_tag => [ "powershell_hidden", "suspicious_cmdline" ]
+        }
+      }
+
+      # Base64 patterns (long base64 strings)
+      if [command_line] =~ /[A-Za-z0-9+\/=]{50,}/ {
+        mutate {
+          add_tag => [ "contains_base64", "suspicious_cmdline" ]
+        }
+      }
+
+      # Common attack tools
+      if [command_line] =~ /(?i)mimikatz|psexec|procdump|lsadump|sekurlsa|kerberos|dcsync/ {
+        mutate {
+          add_tag => [ "attack_tool", "suspicious_cmdline" ]
+        }
+      }
+
+      # Living off the land binaries (LOLBins)
+      if [command_line] =~ /(?i)certutil.*-decode|certutil.*-urlcache|bitsadmin.*\/transfer|mshta\s+http|regsvr32.*\/s.*\/u.*http|rundll32.*javascript|wmic.*process.*call.*create/ {
+        mutate {
+          add_tag => [ "lolbin", "suspicious_cmdline" ]
+        }
+      }
+
+      # Suspicious scripting
+      if [command_line] =~ /(?i)cscript|wscript.*\.vbs|wscript.*\.js/ {
+        mutate {
+          add_tag => [ "scripting_host" ]
+        }
+      }
+
+      # Network operations
+      if [command_line] =~ /(?i)net\s+(user|localgroup|group|share|use|view)|netsh|ipconfig|nslookup|ping/ {
+        mutate {
+          add_tag => [ "network_enumeration" ]
+        }
+      }
+
+      # Lateral movement tools
+      if [command_line] =~ /(?i)psexec|wmic.*\/node|winrs|powershell.*-computer/ {
+        mutate {
+          add_tag => [ "lateral_movement", "suspicious_cmdline" ]
+        }
+      }
+
+      # WMI execution
+      if [command_line] =~ /(?i)wmic.*process.*call.*create/ {
+        mutate {
+          add_tag => [ "wmi_execution", "suspicious_cmdline" ]
+        }
+      }
+
+      # Task scheduler
+      if [command_line] =~ /(?i)schtasks.*\/create|at\s+\d+:\d+/ {
+        mutate {
+          add_tag => [ "scheduled_task", "persistence_mechanism" ]
+        }
+      }
+
+      # Registry operations
+      if [command_line] =~ /(?i)reg\s+add|reg\s+save|reg\s+export/ {
+        mutate {
+          add_tag => [ "registry_modification" ]
+        }
+      }
+
+      # File operations
+      if [command_line] =~ /(?i)copy|move|xcopy|robocopy|del\s+\/f|erase\s+\/f/ {
+        mutate {
+          add_tag => [ "file_operation" ]
+        }
+      }
+
+      # Credential dumping
+      if [command_line] =~ /(?i)lsass|ntds\.dit|sam\s+save|system\s+save/ {
+        mutate {
+          add_tag => [ "credential_dumping", "suspicious_cmdline" ]
+        }
+      }
+    }
+
+    # Calculate command line length
+    if [command_line] {
+      ruby {
+        code => "event.set('cmdline_length', event.get('command_line').length)"
+      }
+
+      # Flag unusually long command lines (often obfuscated)
+      if [cmdline_length] {
+        if [cmdline_length] > 1000 {
+          mutate {
+            add_tag => [ "long_cmdline", "suspicious_cmdline" ]
+          }
+        }
+      }
+    }
+
+    # Classify process type based on name
+    if [process_name] =~ /(?i)powershell|pwsh/ {
+      mutate {
+        add_field => { "process_type" => "powershell" }
+      }
+    } else if [process_name] =~ /(?i)cmd\.exe/ {
+      mutate {
+        add_field => { "process_type" => "cmd" }
+      }
+    } else if [process_name] =~ /(?i)wscript|cscript/ {
+      mutate {
+        add_field => { "process_type" => "script_host" }
+      }
+    } else if [process_name] =~ /(?i)wmic/ {
+      mutate {
+        add_field => { "process_type" => "wmi" }
+      }
+    }
+
+    # Add metadata fields
+    mutate {
+      add_field => {
+        "volatility_plugin" => "windows.cmdline"
+        "analysis_type" => "command_line_analysis"
+      }
+    }
+
+    # Clean up
+    mutate {
+      remove_field => [ "message" ]
+    }
+  }
+}
+
+output {
+  if [type] == "volatility-cmdline" or "volatility-cmdline" in [tags] {
+    elasticsearch {
+      hosts => ["localhost:9200"]
+      index => "volatility-cmdline-%{+YYYY.MM.dd}"
+      document_type => "_doc"
+    }
+  }
+}

--- a/configfiles-UNSUPPORTED/6012-volatility-netstat.conf
+++ b/configfiles-UNSUPPORTED/6012-volatility-netstat.conf
@@ -1,0 +1,164 @@
+# Logstash configuration for Volatility windows.netstat output
+# This parser handles JSON format from Volatility3 windows.netstat plugin
+# Traverses network tracking structures (similar to netstat command)
+#
+# Usage: Place JSON files in the input directory configured below
+# Index Pattern: volatility-netstat-*
+
+filter {
+  # Only process if this is a netstat document
+  if [type] == "volatility-netstat" or "volatility-netstat" in [tags] {
+
+    # Parse JSON if it's a string
+    if [message] {
+      json {
+        source => "message"
+        target => "network"
+      }
+    }
+
+    # Extract network connection information
+    mutate {
+      add_field => {
+        "process_id" => "%{[network][PID]}"
+        "process_name" => "%{[network][Owner]}"
+        "network_protocol" => "%{[network][Proto]}"
+        "local_address" => "%{[network][LocalAddr]}"
+        "local_port" => "%{[network][LocalPort]}"
+        "foreign_address" => "%{[network][ForeignAddr]}"
+        "foreign_port" => "%{[network][ForeignPort]}"
+        "connection_state" => "%{[network][State]}"
+        "network_offset" => "%{[network][Offset]}"
+      }
+      add_tag => [ "volatility", "memory_forensics", "network_analysis", "netstat" ]
+    }
+
+    # Parse connection creation timestamp
+    if [network][Created] {
+      date {
+        match => [ "[network][Created]", "ISO8601", "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ]
+        target => "connection_created_time"
+      }
+    }
+
+    # Convert numeric fields
+    mutate {
+      convert => {
+        "process_id" => "integer"
+        "local_port" => "integer"
+        "foreign_port" => "integer"
+      }
+    }
+
+    # Determine IP version
+    if [network_protocol] =~ /v6$/ {
+      mutate {
+        add_field => { "ip_version" => "IPv6" }
+      }
+    } else {
+      mutate {
+        add_field => { "ip_version" => "IPv4" }
+      }
+    }
+
+    # Classify connection type
+    if [network_protocol] =~ /^TCP/ {
+      mutate {
+        add_field => { "transport_protocol" => "TCP" }
+      }
+    } else if [network_protocol] =~ /^UDP/ {
+      mutate {
+        add_field => { "transport_protocol" => "UDP" }
+      }
+    }
+
+    # Classify connection state
+    if [connection_state] == "LISTENING" {
+      mutate {
+        add_field => { "connection_type" => "listening" }
+      }
+    } else if [connection_state] == "ESTABLISHED" {
+      mutate {
+        add_field => { "connection_type" => "established" }
+      }
+    } else if [connection_state] =~ /CLOSE|FIN|TIME_WAIT/ {
+      mutate {
+        add_field => { "connection_type" => "closing" }
+      }
+    }
+
+    # Check if foreign address is external
+    if [foreign_address] and [foreign_address] != "0.0.0.0" and [foreign_address] != "::" and [foreign_address] != "*" {
+      if [foreign_address] !~ /^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|127\.|::1|fe80:)/ {
+        mutate {
+          add_field => { "connection_scope" => "external" }
+          add_tag => [ "external_connection" ]
+        }
+      } else {
+        mutate {
+          add_field => { "connection_scope" => "internal" }
+        }
+      }
+    }
+
+    # Flag common service ports
+    if [local_port] {
+      if [local_port] == 80 {
+        mutate { add_field => { "service_type" => "http" } }
+      } else if [local_port] == 443 {
+        mutate { add_field => { "service_type" => "https" } }
+      } else if [local_port] == 22 {
+        mutate { add_field => { "service_type" => "ssh" } }
+      } else if [local_port] == 3389 {
+        mutate { add_field => { "service_type" => "rdp" } }
+      } else if [local_port] == 445 {
+        mutate { add_field => { "service_type" => "smb" } }
+      } else if [local_port] == 139 {
+        mutate { add_field => { "service_type" => "netbios" } }
+      } else if [local_port] == 135 {
+        mutate { add_field => { "service_type" => "rpc" } }
+      } else if [local_port] == 53 {
+        mutate { add_field => { "service_type" => "dns" } }
+      }
+    }
+
+    # Add metadata fields
+    mutate {
+      add_field => {
+        "volatility_plugin" => "windows.netstat"
+        "analysis_type" => "network_connections"
+        "detection_method" => "netstat_traversal"
+      }
+    }
+
+    # Mark for correlation with netscan
+    mutate {
+      add_tag => [ "correlate_with_netscan" ]
+    }
+
+    # GeoIP enrichment for foreign addresses
+    if [foreign_address] and [connection_scope] == "external" {
+      geoip {
+        source => "foreign_address"
+        target => "foreign_geo"
+        fields => ["city_name", "country_name", "country_code2", "location", "continent_code"]
+        tag_on_failure => ["_geoip_lookup_failure"]
+      }
+    }
+
+    # Clean up
+    mutate {
+      remove_field => [ "message" ]
+    }
+  }
+}
+
+output {
+  if [type] == "volatility-netstat" or "volatility-netstat" in [tags] {
+    elasticsearch {
+      hosts => ["localhost:9200"]
+      index => "volatility-netstat-%{+YYYY.MM.dd}"
+      document_type => "_doc"
+    }
+  }
+}

--- a/configfiles-UNSUPPORTED/README-volatility.md
+++ b/configfiles-UNSUPPORTED/README-volatility.md
@@ -1,0 +1,19 @@
+# Volatility to SOF-ELK Parsers
+
+Memory forensics parsers for ingesting Volatility3 output into SOF-ELK using the **Filebeat → Logstash → Elasticsearch** architecture.
+
+## Overview
+
+This toolkit provides Filebeat configuration, Logstash filters, and Python preprocessing scripts to parse and index Volatility3 memory forensics output into Elasticsearch via SOF-ELK.
+
+### Supported Volatility3 Plugins (6 Total)
+
+**Tier 1: Process Enumeration (3 plugins)**
+- **windows.pslist** - Lists active processes by walking the process list
+- **windows.pstree** - Shows process hierarchy in a tree structure
+- **windows.psscan** - Scans physical memory for process structures (detects hidden processes)
+
+**Tier 2: Network & Execution Analysis (3 plugins)**
+- **windows.netscan** - Network connections (IPv4/IPv6) with GeoIP enrichment
+- **windows.cmdline** - Command line arguments with attack pattern detection
+- **windows.netstat** - Network statistics (netstat-style enumeration)

--- a/lib/filebeat_inputs/volatility.yml
+++ b/lib/filebeat_inputs/volatility.yml
@@ -1,0 +1,21 @@
+# SOF-ELK® Configuration File
+# (C)2025 Lewes Technology Consulting, LLC
+#
+# This file contains inputs for monitoring Volatility3 memory forensics output
+
+- type: filestream
+  id: volatility-01
+  paths:
+    - /logstash/volatility/**/*.json
+  prospector.scanner.exclude_files: [ 'readme.txt', '\.gz$', '\.bz2$', '\.zip$', '\.bak$', '\.old$' ]
+  close.on_state_change.inactive: 5m
+  clean_removed: true
+  parsers:
+    - ndjson:
+        target: ""
+        overwrite_keys: true
+        add_error_key: true
+  processors:
+    - add_labels:
+        labels:
+          type: volatility

--- a/supporting-scripts/volatility/convert_to_ndjson.py
+++ b/supporting-scripts/volatility/convert_to_ndjson.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Convert Volatility JSON array to NDJSON (newline-delimited JSON)
+================================================================
+Logstash's json_lines codec expects one JSON object per line.
+This script converts Volatility's JSON array format to NDJSON.
+
+Usage:
+    python convert_to_ndjson.py input.json output.ndjson
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def convert_to_ndjson(input_file: Path, output_file: Path):
+    """Convert JSON array to NDJSON format"""
+
+    print(f"Reading: {input_file}")
+    with open(input_file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    # Handle both array and object inputs
+    if isinstance(data, list):
+        records = data
+    elif isinstance(data, dict):
+        # If it's a single object, wrap it in a list
+        records = [data]
+    else:
+        print(f"Error: Unexpected data type: {type(data)}")
+        sys.exit(1)
+
+    print(f"Converting {len(records)} records to NDJSON...")
+    with open(output_file, 'w', encoding='utf-8') as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + '\n')
+
+    print(f"Written to: {output_file}")
+    print(f"Total records: {len(records)}")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python convert_to_ndjson.py <input.json> <output.ndjson>")
+        sys.exit(1)
+
+    input_file = Path(sys.argv[1])
+    output_file = Path(sys.argv[2])
+
+    if not input_file.exists():
+        print(f"Error: Input file not found: {input_file}")
+        sys.exit(1)
+
+    convert_to_ndjson(input_file, output_file)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This contribution adds support for ingesting Volatility3 memory forensics output into SOF-ELK via Filebeat and Logstash.

Added components:
- 8 Logstash filter configurations for 6 Volatility3 plugins (pslist, pstree, psscan, netscan, cmdline, netstat)
- Filebeat input configuration for monitoring Volatility output directories
- Python script for converting Volatility JSON output to NDJSON format
- Documentation covering supported plugins and overview

Features:
- Process enumeration and hidden process detection
- Network connection analysis with GeoIP enrichment
- Command line analysis with attack pattern detection
- Suspicious indicator tagging for threat hunting
