### PR TITLE
Add PECmd (Prefetch) parser under KAPE support - closes #163

### DIFF
--- a/configfiles-UNSUPPORTED/6505-kape_pecmd.conf
+++ b/configfiles-UNSUPPORTED/6505-kape_pecmd.conf
@@ -1,0 +1,153 @@
+# SOF-ELK® Configuration File
+# (C)2026 Lewes Technology Consulting, LLC
+#
+# This file contains filters, transforms, and enrichments for Prefetch logs parsed
+# with the PECmd tool from the Eric Zimmerman/KAPE forensic toolset.
+# Addresses GitHub issue #163.
+
+filter {
+  if [labels][type] == "kape_prefetch" {
+    mutate {
+      # promote the fields of interest out of the [raw] placeholder
+      # the [raw] placeholder is removed by 8005-postprocess-kape.conf
+      rename => {
+        "[raw][SourceFilename]" => "[file][path]"
+        "[raw][SourceCreated]"  => "[file][created]"
+        "[raw][SourceModified]" => "[file][mtime]"
+        "[raw][SourceAccessed]" => "[file][accessed]"
+
+        "[raw][ExecutableName]" => "[prefetch][executable_name]"
+        "[raw][Hash]"           => "[prefetch][hash]"
+        "[raw][Size]"           => "[prefetch][size]"
+        "[raw][Version]"        => "[prefetch][version]"
+        "[raw][RunCount]"       => "[prefetch][run_count]"
+        "[raw][LastRun]"        => "[prefetch][last_run]"
+
+        "[raw][Volume0Name]"    => "[prefetch][volume][name]"
+        "[raw][Volume0Serial]"  => "[volume][serial_number]"
+        "[raw][Volume0Created]" => "[prefetch][volume][created]"
+
+        "[raw][ParsingError]"   => "[prefetch][parsing_error]"
+
+        "[raw][SourceFile]"     => "[file][source_file]"
+      }
+      add_field => { "[file][extension]" => "pf" }
+    }
+
+    # pull just the .pf filename out of the Windows source path for [file][name]
+    # using Ruby (with ASCII 92 for the backslash) to avoid the conf->grok->regex
+    # backslash-escape chain, which is brittle and silently fails
+    if [file][path] {
+      ruby {
+        code => "
+          path = event.get('[file][path]')
+          if path
+            idx = path.rindex(92.chr)
+            event.set('[file][name]', idx ? path[(idx + 1)..-1] : path)
+          end
+        "
+      }
+    }
+
+    # PreviousRun0..PreviousRun7 are individual fields in the JSON.  Collect any
+    # that have a non-empty value into the prefetch.previous_runs array.
+    ruby {
+      code => "
+        prev = []
+        (0..7).each do |i|
+          v = event.get('[raw][PreviousRun' + i.to_s + ']')
+          prev << v unless v.nil? || v.to_s.empty?
+        end
+        event.set('[prefetch][previous_runs]', prev) unless prev.empty?
+        (0..7).each { |i| event.remove('[raw][PreviousRun' + i.to_s + ']') }
+      "
+    }
+
+    # Directories and FilesLoaded are comma-separated strings in PECmd output -
+    # split into arrays for easier searching/aggregation.
+    if [raw][Directories] {
+      mutate {
+        rename => { "[raw][Directories]" => "[prefetch][directories]" }
+        split  => { "[prefetch][directories]" => ", " }
+      }
+    }
+    if [raw][FilesLoaded] {
+      mutate {
+        rename => { "[raw][FilesLoaded]" => "[prefetch][files_loaded]" }
+        split  => { "[prefetch][files_loaded]" => ", " }
+      }
+    }
+
+    # PECmd's default JSON output emits Size and RunCount as quoted strings -
+    # convert to integers so Kibana aggregations (sum, avg, range) work correctly
+    mutate {
+      convert => {
+        "[prefetch][size]"      => "integer"
+        "[prefetch][run_count]" => "integer"
+      }
+    }
+
+    # PECmd emits timestamps in TWO possible formats depending on version/locale:
+    #   - "yyyy-MM-dd HH:mm:ss"             (default for current PECmd builds)
+    #   - "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ"  (ISO8601, older builds or some options)
+    # Each date{} below accepts both, plus the .NET DateTime.MinValue sentinels
+    # that PECmd writes for unset values are stripped first so we don't index a
+    # year-0001 timestamp.
+
+    # clean up known potentially empty/sentinel fields before timestamp conversion
+    if [prefetch][last_run] in [ "", "0001-01-01 00:00:00", "0001-01-01T00:00:00.0000000+00:00" ] {
+      mutate { remove_field => [ "[prefetch][last_run]" ] }
+    }
+    if [prefetch][volume][created] in [ "", "0001-01-01 00:00:00", "0001-01-01T00:00:00.0000000+00:00" ] {
+      mutate { remove_field => [ "[prefetch][volume][created]" ] }
+    }
+
+    # use the most recent execution time for @timestamp; fall back to source mtime
+    if [prefetch][last_run] {
+      date {
+        match => [ "[prefetch][last_run]", "ISO8601", "yyyy-MM-dd HH:mm:ss" ]
+      }
+    } else if [file][mtime] {
+      date {
+        match => [ "[file][mtime]", "ISO8601", "yyyy-MM-dd HH:mm:ss" ]
+      }
+    }
+
+    # convert all timestamp fields to date/time types
+    date {
+      match  => [ "[prefetch][last_run]", "ISO8601", "yyyy-MM-dd HH:mm:ss" ]
+      target => "[prefetch][last_run]"
+    }
+    date {
+      match  => [ "[prefetch][volume][created]", "ISO8601", "yyyy-MM-dd HH:mm:ss" ]
+      target => "[prefetch][volume][created]"
+    }
+    date {
+      match  => [ "[file][created]", "ISO8601", "yyyy-MM-dd HH:mm:ss" ]
+      target => "[file][created]"
+    }
+    date {
+      match  => [ "[file][mtime]", "ISO8601", "yyyy-MM-dd HH:mm:ss" ]
+      target => "[file][mtime]"
+    }
+    date {
+      match  => [ "[file][accessed]", "ISO8601", "yyyy-MM-dd HH:mm:ss" ]
+      target => "[file][accessed]"
+    }
+
+    # build a human-readable summary for the message field / Discover view
+    if [prefetch][executable_name] and [prefetch][run_count] {
+      mutate {
+        replace => { "message" => "Prefetch: %{[prefetch][executable_name]} executed %{[prefetch][run_count]} time(s)" }
+      }
+    } else if [prefetch][executable_name] {
+      mutate {
+        replace => { "message" => "Prefetch: %{[prefetch][executable_name]}" }
+      }
+    } else {
+      mutate {
+        replace => { "message" => "Prefetch record (no executable name parsed)" }
+      }
+    }
+  }
+}

--- a/configfiles/6701-microsoft365.conf
+++ b/configfiles/6701-microsoft365.conf
@@ -1,6 +1,6 @@
 # SOF-ELK® Configuration File
 # (C)2022 Pierre Lidome and Arjun Bhardwaj
-# (C)2025 SOF-ELK integrations and additional parsing features by Lewes Technology Consulting, LLC
+# (C)2026 SOF-ELK integrations and additional parsing features by Lewes Technology Consulting, LLC
 #
 # This file parses JSON-formatted Microsoft 365 UAL files in UTF-8 encoding
 # For some versions of PowerShell, this may require manually specifying the encoding in the "out-file" scriptlet such as:
@@ -110,10 +110,17 @@ filter {
     }
 
     # Break out the ModfiedProperties array to a kv-multi
-    if [raw][ModifiedProperties] and ![raw][ModifiedProperties][0][Name] {
+    if [raw][ModifiedProperties] and ![raw][ModifiedProperties][0] {
+      # empty array - no need to keep it
+      mutate {
+        remove_field => [ "[raw][ModifiedProperties]" ]
+      }
+    }
+    else if [raw][ModifiedProperties] and ![raw][ModifiedProperties][0][Name] {
       # this occasionally occurs when [ModifiedProperties] is a string or an array of strings
       mutate {
-        add_field => { "[raw][ModifiedProperties][flag]" => "%{[raw][ModifiedProperties]}" }
+        rename => { "[raw][ModifiedProperties]" => "[@metadata][ModifiedProperties]" }
+        add_field => { "[raw][ModifiedProperties][flag]" => "%{[@metadata][ModifiedProperties]}" }
       }
     } else if [raw][ModifiedProperties] {
       ruby {

--- a/lib/filebeat_inputs/kape.yml
+++ b/lib/filebeat_inputs/kape.yml
@@ -38,3 +38,18 @@
        labels:
          type: kape_evtxlogs
   tags: [ 'json' ]
+
+- type: filestream
+  id: kape-pecmd-json
+  paths:
+    - /logstash/kape/**/*_PECmd_Output.json
+  # the _PECmd_Output_Timeline.json file is intentionally excluded - it is a
+  # flattened-per-run-time view of the same data already captured here
+  prospector.scanner.exclude_files: [ '_PECmd_Output_Timeline\.json$' ]
+  close.on_state_change.inactive: 5m
+  clean_removed: true
+  processors:
+    - add_labels:
+       labels:
+         type: kape_prefetch
+  tags: [ 'json' ]


### PR DESCRIPTION
## Summary

Adds a parser for [Eric Zimmerman's PECmd](https://ericzimmerman.github.io/) (Prefetch) tool's JSON output. **Closes #163.**

In plain English: Windows keeps small "Prefetch" files (`.pf`) that record every program that has run on the system — execution counts, last-run timestamps, files loaded by the program, etc. PECmd parses those into JSON. This PR teaches SOF-ELK how to ingest that JSON and turn it into a searchable, aggregatable index in Kibana — useful for forensic timeline reconstruction and "what ran on this box" investigations.

Per PR guideline #3, the parser is placed in `configfiles-UNSUPPORTED/`. Happy to move it to `configfiles/` and add `[sof-elk][base_index]` routing in `1000-preprocess-all.conf` plus an index template as a follow-up if the maintainers would prefer.

## Files changed

| File | Status | Purpose |
|---|---|---|
| `configfiles-UNSUPPORTED/6505-kape_pecmd.conf` | new | Logstash filter that processes `labels.type = kape_prefetch` records |
| `lib/filebeat_inputs/kape.yml` | modified (+15 lines) | Adds `kape-pecmd-json` filestream prospector for `*_PECmd_Output.json` |

Structurally modeled on `6503-kape_lecmd.conf` — same author's toolchain, same JSON-output shape.

## Field mapping

| PECmd JSON | SOF-ELK field | Notes |
|---|---|---|
| `SourceFilename` | `file.path` | Full Windows path to the `.pf` file |
| `SourceCreated` / `SourceModified` / `SourceAccessed` | `file.created` / `file.mtime` / `file.accessed` | All converted to date type |
| `ExecutableName` | `prefetch.executable_name` | |
| `Hash` | `prefetch.hash` | |
| `Size` | `prefetch.size` | Converted to integer (PECmd emits as quoted string) |
| `Version` | `prefetch.version` | |
| `RunCount` | `prefetch.run_count` | Converted to integer (same reason) |
| `LastRun` | `prefetch.last_run` + `@timestamp` | Primary timestamp; falls back to `file.mtime` if absent |
| `PreviousRun0..7` | `prefetch.previous_runs[]` | Eight sparse fields folded into a single array of populated values |
| `Volume0Name` | `prefetch.volume.name` | |
| `Volume0Serial` | `volume.serial_number` | Matches LECmd's existing field for cross-artifact pivots |
| `Volume0Created` | `prefetch.volume.created` | Date type |
| `Directories` | `prefetch.directories[]` | Comma-separated string split into array |
| `FilesLoaded` | `prefetch.files_loaded[]` | Comma-separated string split into array |
| `ParsingError` | `prefetch.parsing_error` | Boolean |

The filename portion of `SourceFilename` is also extracted into `file.name` for convenience.

## How an analyst would use this

```
# on a Windows host (admin PowerShell)
PECmd.exe -d C:\Windows\Prefetch --json C:\Temp\pecmd_out

# transfer to SOF-ELK's watched directory
scp C:\Temp\pecmd_out\*_PECmd_Output.json elk_user@<sof-elk-ip>:/logstash/kape/
```

Filebeat picks it up automatically. Documents appear in Kibana under `labels.type : "kape_prefetch"`.

## Test plan

- [x] `logstash -t` passes against the full `conf.d`
- [x] Tested with 2 synthetic records (covers schema correctness, ISO8601 date format)
- [x] Tested with **453 real PECmd records** from a Windows 11 Prefetch directory (covers real-world `yyyy-MM-dd HH:mm:ss` date format and field-shape edge cases)
- [x] All 453 documents present in `logstash-*` indices, no `_grokparsefail_6505-*` or `_dateparsefailure` tags
- [x] `@timestamp` correctly reflects each record's `LastRun` — documents span `logstash-2025.10` through `logstash-2026.06` based on real `LastRun` dates
- [x] `prefetch.previous_runs`, `prefetch.files_loaded`, `prefetch.directories` all render as proper arrays in Kibana
- [x] `prefetch.run_count` is queryable as an integer — verified `labels.type : "kape_prefetch" AND prefetch.run_count > 100` returns 40 hits in Kibana

Tested on SOF-ELK VM revision 2025-10-10 (Ubuntu 24.04.3, Logstash 9.1.5, Filebeat 9.1.5).

## Notes for the reviewer

- **Date format handling:** `date{}` filters accept both `"yyyy-MM-dd HH:mm:ss"` (the default PECmd output) AND `ISO8601`. Different PECmd versions/builds have been observed emitting both, so both are accepted defensively.
- **Numeric coercion:** PECmd emits `Size` and `RunCount` as quoted strings in its JSON output (`"RunCount":"142"` not `"RunCount":142`). A `mutate { convert => integer }` step ensures Kibana aggregations work correctly.
- **Filename extraction:** Uses a small Ruby block with `92.chr` (ASCII backslash) rather than a grok pattern, since the conf→grok→regex backslash-escape chain in Logstash silently fails on some patterns.
- **No IP fields** in Prefetch data, so PR rules 4–6 (GeoIP / ASN enrichment / `ips` array) do not apply.
- **Timeline companion file:** PECmd's `--json` mode also emits a `*_PECmd_Output_Timeline.json` containing the same execution data flattened one-row-per-run. The prospector explicitly excludes this file to avoid duplicate ingestion.